### PR TITLE
Xml-object-stream coffeescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Notes
 * Importing full Wikipedia dump will take a while (several hours, 3:30 to import 2012 dump on quad core machine)
 * Importing full Wikipedia dump will require upto 40 GB of storage space
 * index.coffee requires compile with the following coffee -c index.coffee before use.
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Notes
 
 * Importing full Wikipedia dump will take a while (several hours, 3:30 to import 2012 dump on quad core machine)
 * Importing full Wikipedia dump will require upto 40 GB of storage space
-
+* index.coffee requires compile with the following coffee -c index.coffee before use.
 License
 -------
 


### PR DESCRIPTION
After installing module with  npm install Xml-object-stream, I noticed that it cannot be required because index.js file wasn't generated. I assume that "prepublish": "coffee -c index.coffee" is not executed because coffee-script should be a dependency this is a issue with xml-object-stream and not the git project.
